### PR TITLE
Enable gast texture sharing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
 
     }
     dependencies {
@@ -17,7 +17,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
 
     }
 }

--- a/config.gradle
+++ b/config.gradle
@@ -3,7 +3,7 @@ ext.versions = [
     compileSdk         : 30,
     minSdk             : 18,
     targetSdk          : 30,
-    buildTools         : '30.0.2',
+    buildTools         : '30.0.3',
     kotlinVersion      : '1.5.10',
     ndkVersion         : "21.4.7075529"
 ]

--- a/config.gradle
+++ b/config.gradle
@@ -1,9 +1,9 @@
 ext.versions = [
-    gradlePluginVersion: '4.0.1',
+    gradlePluginVersion: '4.2.1',
     compileSdk         : 30,
     minSdk             : 18,
     targetSdk          : 30,
-    buildTools         : '30.0.1',
-    kotlinVersion      : '1.5.0',
+    buildTools         : '30.0.2',
+    kotlinVersion      : '1.5.10',
     ndkVersion         : "21.4.7075529"
 ]

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -62,5 +62,5 @@ dependencies {
     implementation("androidx.legacy:legacy-support-v4:1.0.0")
 
     // Dependencies for the `plugins` flavor
-    pluginsImplementation("com.google.android.exoplayer:exoplayer:2.11.3")
+    pluginsImplementation("com.google.android.exoplayer:exoplayer:2.14.1")
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -23,19 +23,19 @@ android {
 
     externalNativeBuild {
         cmake {
-            path "CMakeLists.txt"
+            path 'CMakeLists.txt'
         }
     }
 
     flavorDimensions "features"
     productFlavors {
         core {
-            versionCode 19
-            versionName '0.19.0'
+            versionCode 20
+            versionName '0.20.0'
         }
         plugins {
-            versionCode 4
-            versionName "0.4.0"
+            versionCode 5
+            versionName "0.5.0"
         }
     }
 

--- a/core/src/main/cpp/gdn/gast_loader.cpp
+++ b/core/src/main/cpp/gdn/gast_loader.cpp
@@ -21,6 +21,7 @@ void GastLoader::_register_methods() {
     register_method("initialize", &GastLoader::initialize);
     register_method("shutdown", &GastLoader::shutdown);
     register_method("on_physics_process", &GastLoader::on_physics_process);
+    register_method("get_external_texture", &GastLoader::get_external_texture);
 
     // Register signals
     Dictionary common_event_args;
@@ -50,6 +51,14 @@ void GastLoader::shutdown() {
 
 void GastLoader::on_physics_process() {
     GastManager::get_singleton_instance()->on_physics_process();
+}
+
+Ref<ExternalTexture> GastLoader::get_external_texture(const String gast_node_path) {
+    GastNode* gast_node = GastManager::get_singleton_instance()->get_gast_node(gast_node_path);
+    if (!gast_node) {
+        return nullptr;
+    }
+    return gast_node->get_external_texture();
 }
 
 void

--- a/core/src/main/cpp/gdn/gast_loader.h
+++ b/core/src/main/cpp/gdn/gast_loader.h
@@ -3,6 +3,8 @@
 
 #include <core/Godot.hpp>
 #include <core/String.hpp>
+#include <core/Ref.hpp>
+#include <gen/ExternalTexture.hpp>
 #include <gen/Reference.hpp>
 
 namespace gast {
@@ -32,6 +34,8 @@ public:
     void shutdown();
 
     void on_physics_process();
+
+    Ref<ExternalTexture> get_external_texture(const String gast_node_path);
 
     void emitHoverEvent(const String &node_path, const String &event_origin_id, float x_percent,
                         float y_percent);

--- a/core/src/main/cpp/gdn/gast_node.cpp
+++ b/core/src/main/cpp/gdn/gast_node.cpp
@@ -105,20 +105,14 @@ void GastNode::update_collision_shape() {
     }
 }
 
-int GastNode::get_external_texture_id(int surface_index) {
-    if (surface_index == kInvalidSurfaceIndex) {
-        // Default to the first one
-        surface_index = kDefaultSurfaceIndex;
-    }
-
-    Ref<ExternalTexture> external_texture = get_external_texture(surface_index);
+int GastNode::get_external_texture_id() {
     int tex_id = external_texture.is_null() ? kInvalidTexId
                                              : external_texture->get_external_texture_id();
     ALOGV("Retrieved tex id %d", tex_id);
     return tex_id;
 }
 
-Ref<ExternalTexture> GastNode::get_external_texture(int surface_index) {
+Ref<ExternalTexture> GastNode::get_external_texture() {
     return external_texture;
 }
 

--- a/core/src/main/cpp/gdn/gast_node.h
+++ b/core/src/main/cpp/gdn/gast_node.h
@@ -28,7 +28,6 @@ namespace gast {
 namespace {
 using namespace godot;
 constexpr int kInvalidTexId = -1;
-constexpr int kInvalidSurfaceIndex = -1;
 const bool kDefaultCollidable = true;
 }  // namespace
 
@@ -57,7 +56,9 @@ public:
 
     void _notification(const int64_t what);
 
-    int get_external_texture_id(int surface_index = kInvalidSurfaceIndex);
+    Ref<ExternalTexture> get_external_texture();
+
+    int get_external_texture_id();
 
     inline void set_collidable(bool collidable) {
         if (this->collidable == collidable) {
@@ -181,8 +182,6 @@ private:
         // Replace the '/' character with a '_' character
         return node_name.replace("/", "_") + "_down_scroll";
     }
-
-    Ref<ExternalTexture> get_external_texture(int surface_index);
 
     void update_collision_shape();
 

--- a/core/src/main/cpp/jni/gast_node_jni.cpp
+++ b/core/src/main/cpp/jni/gast_node_jni.cpp
@@ -73,10 +73,10 @@ JNI_METHOD(updateGastNodeParent)(JNIEnv *env, jobject, jlong node_pointer,
 }
 
 JNIEXPORT jint JNICALL
-JNI_METHOD(getTextureId)(JNIEnv *, jobject, jlong node_pointer, jint surface_index) {
+JNI_METHOD(getTextureId)(JNIEnv *, jobject, jlong node_pointer) {
     GastNode *gast_node = from_pointer(node_pointer);
     ERR_FAIL_NULL_V(gast_node, kInvalidTexId);
-    return gast_node->get_external_texture_id(surface_index);
+    return gast_node->get_external_texture_id();
 }
 
 JNIEXPORT void JNICALL

--- a/core/src/main/java/org/godotengine/plugin/gast/GastNode.kt
+++ b/core/src/main/java/org/godotengine/plugin/gast/GastNode.kt
@@ -104,7 +104,6 @@ class GastNode @JvmOverloads constructor(
 
     companion object {
         private val TAG = GastNode::class.java.simpleName
-        private const val INVALID_SURFACE_INDEX = -1
         private const val INVALID_TEX_ID = 0
         private const val INVALID_NODE_POINTER = 0L;
         private const val RELEASED_PATH = ""
@@ -244,16 +243,12 @@ class GastNode @JvmOverloads constructor(
     /**
      * Get the texture id for the Gast node with the given path.
      */
-    @JvmOverloads
-    fun getTextureId(surfaceIndex: Int = INVALID_SURFACE_INDEX): Int {
+    fun getTextureId(): Int {
         checkIfReleased()
-        return getTextureId(nodePointer, surfaceIndex)
+        return getTextureId(nodePointer)
     }
 
-    private external fun getTextureId(
-        nodePointer: Long,
-        surfaceIndex: Int
-    ): Int
+    private external fun getTextureId(nodePointer: Long): Int
 
     /**
      * Update the node's name.

--- a/core/src/plugins/java/org/godotengine/plugin/gast/plugins/video/GastVideoPlugin.kt
+++ b/core/src/plugins/java/org/godotengine/plugin/gast/plugins/video/GastVideoPlugin.kt
@@ -66,7 +66,7 @@ class GastVideoPlugin(godot: Godot) : GastExtension(godot), Player.EventListener
 
     private fun isInitialized() = gastNode != null && !gastNode!!.isReleased()
 
-    private fun setVideoNodePath(parentNodePath: String) {
+    private fun setVideoNodePath(parentNodePath: String, nodeName: String) {
         if (TextUtils.isEmpty(parentNodePath)) {
             Log.e(TAG, "Invalid parent node path value: $parentNodePath")
             return
@@ -77,6 +77,10 @@ class GastVideoPlugin(godot: Godot) : GastExtension(godot), Player.EventListener
                 gastNode?.updateParent(parentNodePath)
             } else {
                 gastNode = GastNode(gastManager, parentNodePath)
+            }
+
+            if (nodeName.isNotBlank()) {
+                gastNode?.setName(nodeName)
             }
 
             runOnUiThread {
@@ -131,8 +135,8 @@ class GastVideoPlugin(godot: Godot) : GastExtension(godot), Player.EventListener
      */
     @Suppress("unused")
     @UsedByGodot
-    fun preparePlayer(parentNodePath: String, videoRawNames: Array<String>) {
-        setVideoNodePath(parentNodePath)
+    fun preparePlayer(parentNodePath: String, nodeName: String, videoRawNames: Array<String>) {
+        setVideoNodePath(parentNodePath, nodeName)
         setVideoSource(videoRawNames)
     }
 

--- a/core/src/plugins/java/org/godotengine/plugin/gast/plugins/video/GastVideoPlugin.kt
+++ b/core/src/plugins/java/org/godotengine/plugin/gast/plugins/video/GastVideoPlugin.kt
@@ -56,7 +56,7 @@ class GastVideoPlugin(godot: Godot) : GastExtension(godot), Player.EventListener
     override fun onPositionDiscontinuity(@Player.DiscontinuityReason reason: Int) {
         when (reason) {
 
-            Player.DISCONTINUITY_REASON_PERIOD_TRANSITION, Player.DISCONTINUITY_REASON_SEEK -> {
+            Player.DISCONTINUITY_REASON_AUTO_TRANSITION, Player.DISCONTINUITY_REASON_SEEK -> {
                 // TODO: use to detect when switching video in a playlist
             }
             else -> {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jan 11 11:06:06 PST 2021
+#Tue Jun 22 12:14:03 PDT 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/samples/video_demo/godot/Main.gd
+++ b/samples/video_demo/godot/Main.gd
@@ -18,7 +18,10 @@ var gast_video_plugin = null
 
 var curved = false
 
+onready var second_screen: MeshInstance = $SecondScreen
+
 func _ready():
+	_initialize_second_screen_shader()
 	_initialize_ovr_mobile_arvr_interface()
 	gast = gast_loader.new()
 	gast.initialize()
@@ -27,7 +30,7 @@ func _ready():
 	if Engine.has_singleton("gast-video"):
 		print("Setting video player...")
 		gast_video_plugin = Engine.get_singleton("gast-video")
-		gast_video_plugin.preparePlayer("/root/Main/VideoContainer", ["flight"])
+		gast_video_plugin.preparePlayer("/root/Main/VideoContainer", "video-player", ["flight"])
 		gast_video_plugin.play()
 		gast_video_plugin.setRepeatMode(2)
 		gast_video_plugin.setVideoScreenSize(3.54, 2)
@@ -38,10 +41,43 @@ func _ready():
 func _process(delta_t):
 	_check_inputs()
 	_check_and_perform_runtime_config()
+	_setup_second_screen()
 
 
 func _physics_process(delta_t):
 	gast.on_physics_process()
+
+
+func _initialize_second_screen_shader():
+	var shader_material : ShaderMaterial = second_screen.get_surface_material(0)
+	var shader : Shader = shader_material.shader
+	print("Setting shader custom defines")
+	shader.custom_defines = """#ifdef ANDROID_ENABLED
+	#extension GL_OES_EGL_image_external : enable
+	#extension GL_OES_EGL_image_external_essl3 : enable
+	#else
+	#define samplerExternalOES sampler2D
+	#endif"""
+
+
+var _check_for_external_texture = false
+func _setup_second_screen():
+	if (_check_for_external_texture):
+		return
+
+	print("Checking for external texture.")
+	var external_texture: ExternalTexture = gast.get_external_texture("video-player")
+	if (external_texture == null):
+		return
+
+	print("Valid external texture with id " + str(external_texture.get_external_texture_id()))
+	_check_for_external_texture = true
+
+	# Setup the second screen
+	second_screen.visible = true
+	var shader_material : ShaderMaterial = second_screen.get_surface_material(0)
+	print("Setting shader params.")
+	shader_material.set_shader_param("external_texture", external_texture)
 
 
 func _check_inputs():
@@ -68,7 +104,7 @@ func _initialize_ovr_mobile_arvr_interface():
 		print("Couldn't find OVRMobile interface")
 	else:
 		ovrVrApiTypes = load("res://addons/godot_ovrmobile/OvrVrApiTypes.gd").new()
-		
+
 		# the init config needs to be done before arvr_interface.initialize()
 		ovr_init_config = load("res://addons/godot_ovrmobile/OvrInitConfig.gdns")
 		if (ovr_init_config):

--- a/samples/video_demo/godot/Main.tscn
+++ b/samples/video_demo/godot/Main.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://touch_controller.tscn" type="PackedScene" id=1]
 [ext_resource path="res://Main.gd" type="Script" id=2]
 [ext_resource path="res://ray_cast.tscn" type="PackedScene" id=3]
+[ext_resource path="res://second_screen_shader.shader" type="Shader" id=4]
 
 [sub_resource type="SpatialMaterial" id=1]
 albedo_color = Color( 0.929412, 0.858824, 0.858824, 1 )
@@ -11,6 +12,11 @@ albedo_color = Color( 0.929412, 0.858824, 0.858824, 1 )
 material = SubResource( 1 )
 radius = 0.004
 mid_height = 0.5
+
+[sub_resource type="QuadMesh" id=3]
+
+[sub_resource type="ShaderMaterial" id=5]
+shader = ExtResource( 4 )
 
 [node name="Main" type="Spatial"]
 script = ExtResource( 2 )
@@ -50,3 +56,9 @@ mesh = SubResource( 2 )
 material/0 = null
 
 [node name="RightRayCast" parent="ARVROrigin/RightTouchController/MeshInstance" instance=ExtResource( 3 )]
+
+[node name="SecondScreen" type="MeshInstance" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.448328, 1.10173, -0.5513 )
+visible = false
+mesh = SubResource( 3 )
+material/0 = SubResource( 5 )

--- a/samples/video_demo/godot/second_screen_shader.shader
+++ b/samples/video_demo/godot/second_screen_shader.shader
@@ -1,0 +1,9 @@
+shader_type spatial;
+
+render_mode unshaded;
+
+uniform samplerExternalOES external_texture;
+
+void fragment() {
+	ALBEDO = texture(external_texture, UV).rgb;
+}


### PR DESCRIPTION
This PR adds a `get_external_texture("")` method to allow retrieval of the [`ExternalTexture`](https://docs.godotengine.org/en/stable/classes/class_externaltexture.html) of a `GastNode` node.

See the update in `Main.gd` for an example on how to use it.