### PR TITLE
Use VIEW_INDEX shader uniform to perform per-eye rendering

### DIFF
--- a/config.gradle
+++ b/config.gradle
@@ -9,8 +9,8 @@ ext.versions = [
     javaVersion        : JavaVersion.VERSION_1_8,
     kotlinJvmTarget    : '1.8',
     multidex_version   : "2.0.1",
-    coreVersionCode    : 2700,
-    coreVersionName    : '0.27.0',
+    coreVersionCode    : 2701,
+    coreVersionName    : '0.27.1',
     pluginsVersionCode : 600,
     pluginsVersionName : '0.6.0',
 ]

--- a/core/src/main/cpp/gdn/gast_node.cpp
+++ b/core/src/main/cpp/gdn/gast_node.cpp
@@ -199,7 +199,6 @@ void GastNode::_notification(const int64_t what) {
 }
 
 void GastNode::_process(const real_t delta) {
-    update_projection_mesh_camera_uniforms();
     if (is_gaze_tracking()) {
         Rect2 gaze_area = get_viewport()->get_visible_rect();
         Vector2 gaze_center_point = Vector2(gaze_area.position.x + gaze_area.size.x / 2.0,
@@ -339,14 +338,6 @@ Vector2 GastNode::get_relative_collision_point(Vector3 absolute_collision_point)
     } else {
         // TODO: Implement for other projection mesh types.
         return kInvalidCoordinate;
-    }
-}
-
-void GastNode::update_projection_mesh_camera_uniforms() {
-    if (projection_mesh) {
-        Transform camera_global_transform = get_viewport()->get_camera()->get_global_transform();
-        projection_mesh->set_camera_uniforms(
-            camera_global_transform.origin, camera_global_transform.basis.x.normalized());
     }
 }
 

--- a/core/src/main/cpp/gdn/gast_node.h
+++ b/core/src/main/cpp/gdn/gast_node.h
@@ -149,8 +149,6 @@ private:
 
     void update_collision_shape();
 
-    void update_projection_mesh_camera_uniforms();
-
     ProjectionMeshPool projection_mesh_pool;
     ProjectionMesh *projection_mesh = nullptr;
     Ref<ExternalTexture> external_texture;

--- a/core/src/main/cpp/gdn/projection_mesh/projection_mesh.cpp
+++ b/core/src/main/cpp/gdn/projection_mesh/projection_mesh.cpp
@@ -255,10 +255,6 @@ void ProjectionMesh::update_shader_param(int index, const String &param,
     }
 }
 
-void ProjectionMesh::set_camera_uniforms(Vector3 camera_position, Vector3 camera_xaxis) const {
-    update_shaders_param(kCameraPositionParamName, camera_position);
-    update_shaders_param(kCameraXaxisParamName, camera_xaxis);
-}
 
 }  // namespace gast
 

--- a/core/src/main/cpp/gdn/projection_mesh/projection_mesh.h
+++ b/core/src/main/cpp/gdn/projection_mesh/projection_mesh.h
@@ -3,7 +3,6 @@
 
 #include <core/Ref.hpp>
 #include <core/Vector2.hpp>
-#include <core/Vector3.hpp>
 #include <gen/CollisionShape.hpp>
 #include <gen/ExternalTexture.hpp>
 #include <gen/MeshInstance.hpp>
@@ -24,8 +23,6 @@ const char *kGastTextureParamName = "gast_texture";
 const char *kGastEnableBillBoardParamName = "enable_billboard";
 const char *kGastGradientHeightRatioParamName = "gradient_height_ratio";
 const char *kGastNodeAlphaParamName = "node_alpha";
-const char *kCameraPositionParamName = "camera_position";
-const char *kCameraXaxisParamName = "camera_xaxis";
 const int kDefaultSurfaceIndex = 0;
 const Vector2 kInvalidCoordinate = Vector2(-1, -1);
 const bool kDefaultCollidable = true;
@@ -177,8 +174,6 @@ public:
     void update_collision_shapes() const;
 
     virtual void update_properties(ProjectionMesh *projection_mesh);
-
-    void set_camera_uniforms(Vector3 camera_position, Vector3 camera_xaxis) const;
 
 protected:
     struct ProjectionMeshData {

--- a/core/src/main/cpp/gdn/projection_mesh/projection_mesh_utils.h
+++ b/core/src/main/cpp/gdn/projection_mesh/projection_mesh_utils.h
@@ -24,8 +24,6 @@ uniform mat4 right_eye_sampling_transform;
 uniform bool enable_billboard;
 uniform float gradient_height_ratio;
 uniform float node_alpha = 1.0;
-uniform vec3 camera_position;
-uniform vec3 camera_xaxis;
 
 // Specifies which view index this shader should apply:
 // -1 for both
@@ -40,16 +38,8 @@ void vertex() {
 }
 
 void fragment() {
-    // Find world camera position (different for each eye)
-    vec3 world_camera = (CAMERA_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)).xyz;
-    // Find projection position
-    vec3 world_projection = camera_position;
-    // Find difference between projection and camera on X-Axis
-    vec3 diff = world_camera - world_projection;
-    float diff_dot = dot(camera_xaxis, diff);
-
     vec2 new_uv = UV;
-    if(diff_dot > 0.0f) {
+    if (VIEW_INDEX == VIEW_RIGHT) {
         // Right Eye
         if (shader_view_index == 0) {
             // Discarding since this shader should only render for the left (0) view index.


### PR DESCRIPTION
This replaces the workaround implemented in https://github.com/m4gr3d/GAST/pull/32.